### PR TITLE
versioning: CLI for linking upgraded records

### DIFF
--- a/zenodo_migrator/version.py
+++ b/zenodo_migrator/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0.dev20170529"
+__version__ = "1.0.0.dev20170606"


### PR DESCRIPTION
* Allows for linking multiple records together if
  at most one of the records was already upgraded.

* Allows for reordering versions within single version scheme as well.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>